### PR TITLE
Update to ensure that kubernetes cluster is always pulling newest image

### DIFF
--- a/gcloud_deploy.yaml
+++ b/gcloud_deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: arxaas
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: arxaas
@@ -17,5 +17,6 @@ spec:
       containers:
       - name: arxaas
         image: arxaas/aaas:latest
+        imagePullPolicy: "Always"
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Seems to be some problem with kubernetes not pulling from docker every time.